### PR TITLE
Fix availability slot rounding

### DIFF
--- a/lib/state/availability_utils.dart
+++ b/lib/state/availability_utils.dart
@@ -1,0 +1,9 @@
+import 'dart:math' as math;
+
+List<DateTime> generateOccupiedSlots(DateTime start, Duration duration) {
+  final slots = math.max(1, (duration.inMinutes + 29) ~/ 30);
+  return List<DateTime>.generate(
+    slots,
+    (index) => start.add(Duration(minutes: 30 * index)),
+  );
+}

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -15,6 +15,7 @@ import '../data/repositories/promotion_repository.dart';
 import '../data/repositories/storage_repository.dart';
 import '../data/services/notifications_service.dart';
 import '../data/services/supabase_client.dart';
+import 'availability_utils.dart';
 
 final supabaseClientProvider = Provider<SupabaseClient>((ref) => SupabaseService.client);
 
@@ -215,10 +216,7 @@ final availabilityProvider = FutureProvider.family<List<DateTime>, AvailabilityP
       .map((appointment) {
         final start = DateTime.parse(appointment['scheduled_at'] as String).toLocal();
         final duration = Duration(minutes: appointment['duration_minutes'] as int? ?? 30);
-        return List<DateTime>.generate(
-          duration.inMinutes ~/ 30,
-          (index) => start.add(Duration(minutes: 30 * index)),
-        );
+        return generateOccupiedSlots(start, duration);
       })
       .expand((element) => element)
       .toSet();

--- a/test/state/availability_utils_test.dart
+++ b/test/state/availability_utils_test.dart
@@ -1,0 +1,25 @@
+import 'package:berberim_yanimda/state/availability_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('generateOccupiedSlots', () {
+    test('returns at least one slot for durations shorter than 30 minutes', () {
+      final start = DateTime(2024, 1, 1, 10, 0);
+
+      final slots = generateOccupiedSlots(start, const Duration(minutes: 15));
+
+      expect(slots, [start]);
+    });
+
+    test('rounds up durations to the next 30-minute block', () {
+      final start = DateTime(2024, 1, 1, 10, 0);
+
+      final slots = generateOccupiedSlots(start, const Duration(minutes: 45));
+
+      expect(slots, [
+        start,
+        start.add(const Duration(minutes: 30)),
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- introduce a helper to generate occupied 30-minute slots for appointments
- update the availability provider to round appointment durations up to 30-minute blocks
- add tests covering short (15 min) and mid-length (45 min) durations

## Testing
- flutter test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0c9dba988332872beace4e8bf1f7