### PR TITLE
Make payment method selection stateful on payment page

### DIFF
--- a/lib/features/payments/payment_page.dart
+++ b/lib/features/payments/payment_page.dart
@@ -1,7 +1,41 @@
 import 'package:flutter/material.dart';
 
-class PaymentPage extends StatelessWidget {
+class PaymentPage extends StatefulWidget {
   const PaymentPage({super.key});
+
+  @override
+  State<PaymentPage> createState() => _PaymentPageState();
+}
+
+class _PaymentPageState extends State<PaymentPage> {
+  String _selectedMethod = 'card';
+
+  void _updateSelection(String? value) {
+    if (value == null) return;
+    setState(() {
+      _selectedMethod = value;
+    });
+  }
+
+  void _completePayment(BuildContext context) {
+    late final String message;
+
+    switch (_selectedMethod) {
+      case 'card':
+        message = 'Stripe entegrasyonu yakında.';
+        break;
+      case 'mobile':
+        message = 'Mobil ödeme seçeneği yakında kullanımda olacak.';
+        break;
+      case 'onsite':
+        message = 'Ödemenizi randevu gününde salonda gerçekleştirebilirsiniz.';
+        break;
+      default:
+        message = 'Ödeme yöntemi seçilemedi.';
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(message)));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -16,28 +50,26 @@ class PaymentPage extends StatelessWidget {
             const SizedBox(height: 16),
             RadioListTile<String>(
               value: 'card',
-              groupValue: 'card',
-              onChanged: (_) {},
+              groupValue: _selectedMethod,
+              onChanged: _updateSelection,
               title: const Text('Kredi/Banka Kartı (Stripe placeholder)'),
               subtitle: const Text('Güvenli ödeme için yönlendirileceksiniz.'),
             ),
             RadioListTile<String>(
               value: 'mobile',
-              groupValue: 'card',
-              onChanged: (_) {},
+              groupValue: _selectedMethod,
+              onChanged: _updateSelection,
               title: const Text('Mobil Ödeme'),
             ),
             RadioListTile<String>(
               value: 'onsite',
-              groupValue: 'card',
-              onChanged: (_) {},
+              groupValue: _selectedMethod,
+              onChanged: _updateSelection,
               title: const Text('Salonda Öde'),
             ),
             const Spacer(),
             FilledButton(
-              onPressed: () {
-                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Stripe entegrasyonu yakında.')));
-              },
+              onPressed: () => _completePayment(context),
               child: const Text('Ödemeyi Tamamla'),
             ),
           ],


### PR DESCRIPTION
## Summary
- convert PaymentPage into a StatefulWidget with a tracked selection
- bind radio buttons to the state and update selection when changed
- adjust the completion button message according to the chosen payment method

## Testing
- not run (Flutter/Dart SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cc0c993e9883329f757994c5678f3f