### PR TITLE
Add mounted checks before setState in confirm booking page

### DIFF
--- a/lib/features/booking/confirm_page.dart
+++ b/lib/features/booking/confirm_page.dart
@@ -27,6 +27,7 @@ class _ConfirmBookingPageState extends ConsumerState<ConfirmBookingPage> {
   Future<void> _load() async {
     final booking = ref.read(bookingProvider);
     if (booking.businessId == null || booking.services.isEmpty) {
+      if (!mounted) return;
       setState(() => _loading = false);
       return;
     }
@@ -35,6 +36,7 @@ class _ConfirmBookingPageState extends ConsumerState<ConfirmBookingPage> {
     query.eq('business_id', booking.businessId);
     query.in_('id', booking.services.toList());
     final response = await query;
+    if (!mounted) return;
     final services = response
         .map(
           (json) => ServiceModel(


### PR DESCRIPTION
## Summary
- add mounted guard before calling setState in the confirm booking page load method

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0c9a62bc83328a9d1c382b5ad931