### PR TITLE
Ensure mounted checks before state updates on business pages

### DIFF
--- a/lib/features/business/requests_page.dart
+++ b/lib/features/business/requests_page.dart
@@ -30,11 +30,13 @@ class _BusinessRequestsPageState extends ConsumerState<BusinessRequestsPage> {
         .maybeSingle();
     final businessId = profile?['default_business_id'] as String?;
     if (businessId == null) {
+      if (!mounted) return;
       setState(() => _loading = false);
       return;
     }
     final repo = ref.read(appointmentRepositoryProvider);
     final data = await repo.fetchAppointments(businessId: businessId);
+    if (!mounted) return;
     setState(() {
       _businessId = businessId;
       _requests = data.where((appointment) => appointment.status == 'pending').toList();
@@ -45,6 +47,7 @@ class _BusinessRequestsPageState extends ConsumerState<BusinessRequestsPage> {
   Future<void> _updateStatus(Appointment appointment, String status) async {
     final client = ref.read(supabaseClientProvider);
     await client.from('appointments').update({'status': status}).eq('id', appointment.id);
+    if (!mounted) return;
     setState(() {
       _requests = _requests.where((item) => item.id != appointment.id).toList();
     });

--- a/lib/features/business_detail/business_detail_page.dart
+++ b/lib/features/business_detail/business_detail_page.dart
@@ -44,6 +44,7 @@ class _BusinessDetailPageState extends ConsumerState<BusinessDetailPage> {
         .order('created_at', ascending: false)
         .limit(20);
 
+    if (!mounted) return;
     setState(() {
       _business = business == null
           ? null


### PR DESCRIPTION
## Summary
- add mounted guards before setState in business requests async flows
- guard business detail load state updates with mounted check

## Testing
- flutter analyze *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0c9f864c83328ff553c9e7b29c0a